### PR TITLE
Add option to 'Organize Imports'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Formats all files in the current workspace/selected folder/glob.  Due to the lim
 * `formatFiles.extensionsToInclude`: [ *default*: '\*' ]<br>comma delimted list of extensions to include, i.e. "ts,js,cp,cs", if this is not specified all extensions are included
 * `formatFiles.excludePattern`: [ *default*: '\*\*/node_modules, \*\*/.vscode, \*\*/dist/\*\*, \*\*/.chrome']<br>GlobPattern of paths to exclude.  Default excludePattern specifies node_modules and .vscode folder
 * `formatFiles.inheritWorkspaceExcludedFiles`: [*default*: `true`]<br>Specifies that workspace globs specified in `files.exclude` that are `true` will be included in exclude glob
+* `formatFiles.runOrganizeImports`: [*default*: `true`]<br>Additionally organize all imports when formatting files (Uses the built-in 'Organize Imports' command, which is supported by some languages)
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,12 @@
             "type": "boolean",
             "description": "Determines if Format Files will inherit workspace excluded files",
             "default": true
+          },
+          "formatFiles.runOrganizeImports": {
+            "scope": "resource",
+            "type": "boolean",
+            "description": "Whether or not to run 'Organize Imports' when formatting files",
+            "default": false
           }
         }
       }

--- a/src/ext/commands/format-files.ts
+++ b/src/ext/commands/format-files.ts
@@ -2,6 +2,7 @@ import { commands, ProgressLocation, Uri, ViewColumn, window } from 'vscode';
 import { Logger } from '../utilities/logger';
 import { tryOpenDocument } from './try-open-document';
 import { OperationAborted } from '../errors/operation-aborted';
+import { Config } from '../utilities/config';
 
 const logger = new Logger('format-files');
 
@@ -43,6 +44,9 @@ async function formatFile(file: Uri): Promise<void> {
 
   if (doc) {
     await window.showTextDocument(doc, { preview: false, viewColumn: ViewColumn.One });
+    if (Config.instance.runOrganizeImports) {
+      await commands.executeCommand('editor.action.organizeImports');
+    }
     await commands.executeCommand('editor.action.formatDocument');
     await commands.executeCommand('workbench.action.files.save');
     await commands.executeCommand('workbench.action.closeActiveEditor');

--- a/src/ext/utilities/config.ts
+++ b/src/ext/utilities/config.ts
@@ -5,6 +5,7 @@ interface FormatFilesConfig {
   extensionsToInclude?: string;
   excludePattern?: string;
   inheritWorkspaceExcludedFiles?: boolean;
+  runOrganizeImports?: boolean;
 }
 
 export class Config {
@@ -32,6 +33,10 @@ export class Config {
 
   public get inheritWorkspaceExcludedFiles(): boolean {
     return this._formatFilesConfig.inheritWorkspaceExcludedFiles ?? false;
+  }
+
+  public get runOrganizeImports(): boolean {
+    return this._formatFilesConfig.runOrganizeImports ?? false;
   }
 
   public get workspaceExcludes(): string[] {


### PR DESCRIPTION
VS Code has an `editor.action.organizeImports` command that organizes imports (e.g. removes unused imports, sorts alphabetically). Works for js/ts, and any other language that supports the editor command.

By default this option is off, to preserve backwards compatability.