### PR TITLE
Changing how extensions are handled to be more consistent with exclud…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Formats all files in the current workspace/selected folder/glob.  Due to the lim
 
 ### Options
 
-* `formatFiles.extensionsToInclude`: [ *default*: '\*' ]<br>comma delimited list of extensions to include between brace, i.e. "{ts,js,cp,cs}", if this is not specified all extensions are included
+* `formatFiles.extensionsToInclude`: [ *default*: '\*' ]<br>comma delimited list of extensions to include, i.e. "ts,js,cp,cs", if this is not specified all extensions are included
 * `formatFiles.excludePattern`: [ *default*: '\*\*/node_modules, \*\*/.vscode, \*\*/dist/\*\*, \*\*/.chrome']<br>GlobPattern of paths to exclude.  Default excludePattern specifies node_modules and .vscode folder
 * `formatFiles.inheritWorkspaceExcludedFiles`: [*default*: `true`]<br>Specifies that workspace globs specified in `files.exclude` that are `true` will be included in exclude glob
 * `formatFiles.runOrganizeImports`: [*default*: `true`]<br>Additionally organize all imports when formatting files (Uses the built-in 'Organize Imports' command, which is supported by some languages)

--- a/src/ext/queries/get-files.ts
+++ b/src/ext/queries/get-files.ts
@@ -27,7 +27,11 @@ export class GetFiles {
 
   private getIncludeGlob(): string {
     this._logger.info(`creating include glob`);
-    const glob = `**/*.${this._config.extensionsToInclude}`;
+    const includes = this._config.extensionsToInclude
+      .split(',')
+      .map((inc) => '**/*.' + inc.trim());
+
+    const glob = `{${includes.join(',')}}`;
     this._logger.info(`\t${glob}`);
     return glob;
   }


### PR DESCRIPTION
…e-settings (no braces necessary)

This PR addresses #22 - I think requiring the user to add curly braces for the includes in the settings.json file is somehow not obvious, just using a comma-separated list is easier to understand. It also aligns the usage with the exclude pattern. 