### PR TITLE
Add command to format all files changed in a feature branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
             "type": "boolean",
             "description": "If the workspace folder is a git repository, skips files that git ignores",
             "default": true
+          },
+          "formatFiles.lastBranch": {
+            "scope": "application",
+            "type": "string",
+            "description": "Last branch name used for branch-based formatting",
+            "default": ""
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "activationEvents": [
     "onCommand:formatFiles.start.workspace",
     "onCommand:formatFiles.start.workspaceFolder",
-    "onCommand:formatFiles.start.fromGlob"
+    "onCommand:formatFiles.start.fromGlob",
+    "onCommand:formatFiles.start.fromBranch"
   ],
   "main": "./out/extension",
   "extensionDependencies": [
@@ -102,6 +103,10 @@
       {
         "command": "formatFiles.start.fromGlob",
         "title": "Start Format Files: From Glob"
+      },
+      {
+        "command": "formatFiles.start.fromBranch",
+        "title": "Start Format Files: Changed in Branch"
       }
     ],
     "menus": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export class Constants {
   public static readonly formatFiles = 'formatFiles.start.workspace';
   public static readonly formatFilesFolder = 'formatFiles.start.workspaceFolder';
   public static readonly formatFilesFromGlob = 'formatFiles.start.fromGlob';
+  public static readonly formatFilesFromBranch = 'formatFiles.start.fromBranch';
 
   public static skipExcludes = false;
 }

--- a/src/ext/prompts/index.ts
+++ b/src/ext/prompts/index.ts
@@ -1,8 +1,9 @@
 import { confirmStart } from './confirm-start';
 import { requestGlob } from './request-glob';
+import { requestBranch } from './request-branch';
 import { selectWorkspaceFolder } from './select-workspace-folder';
 import { useDefaultExcludes } from './use-default-excludes';
 
-const prompts = { requestGlob, useDefaultExcludes, confirmStart, selectWorkspaceFolder };
+const prompts = { requestGlob, requestBranch, useDefaultExcludes, confirmStart, selectWorkspaceFolder };
 
 export default prompts;

--- a/src/ext/prompts/request-branch.ts
+++ b/src/ext/prompts/request-branch.ts
@@ -8,7 +8,7 @@ const LAST_BRANCH_KEY = 'formatFiles.lastBranch';
 export async function requestBranch(): Promise<string> {
   const lastBranch = getLastBranch();
   const placeholder = lastBranch ? `Enter target branch (last used: ${lastBranch})` : 'Enter target branch (e.g., main, master, develop)';
-  
+
   const maybeBranch = await window.showInputBox({
     ignoreFocusOut: true,
     placeHolder: placeholder,

--- a/src/ext/prompts/request-branch.ts
+++ b/src/ext/prompts/request-branch.ts
@@ -1,0 +1,51 @@
+import { window, workspace } from 'vscode';
+import { OperationAborted } from '../errors/operation-aborted';
+import { Logger } from '../utilities/logger';
+
+const logger = new Logger('request-branch');
+const LAST_BRANCH_KEY = 'formatFiles.lastBranch';
+
+export async function requestBranch(): Promise<string> {
+  const lastBranch = getLastBranch();
+  const placeholder = lastBranch ? `Enter target branch (last used: ${lastBranch})` : 'Enter target branch (e.g., main, master, develop)';
+  
+  const maybeBranch = await window.showInputBox({
+    ignoreFocusOut: true,
+    placeHolder: placeholder,
+    prompt: 'Format Files changed compared to branch - press esc to cancel',
+    value: lastBranch,
+  });
+
+  logger.info(`branch entered: ${maybeBranch}`);
+
+  if (!maybeBranch) {
+    throw new OperationAborted('Branch name undefined or empty');
+  }
+
+  const confirmed = await confirmBranchInput(maybeBranch);
+  if (!confirmed) {
+    throw new OperationAborted('User aborted');
+  }
+
+  // Save the branch for next time
+  await saveLastBranch(maybeBranch);
+
+  return maybeBranch;
+}
+
+async function confirmBranchInput(branch: string): Promise<boolean> {
+  const result = await window.showQuickPick(['Yes', 'No'], {
+    ignoreFocusOut: true,
+    placeHolder: `Compare and format files changed since '${branch}', is that correct?`,
+  });
+
+  return result === 'Yes';
+}
+
+function getLastBranch(): string | undefined {
+  return workspace.getConfiguration().get<string>(LAST_BRANCH_KEY);
+}
+
+async function saveLastBranch(branch: string): Promise<void> {
+  await workspace.getConfiguration().update(LAST_BRANCH_KEY, branch, true);
+}

--- a/src/ext/utilities/git.ts
+++ b/src/ext/utilities/git.ts
@@ -1,6 +1,7 @@
 import { extensions, Uri } from 'vscode';
 import { Logger } from './logger';
 import { execFileSync } from 'child_process';
+import * as path from 'path';
 
 export class Git {
   private _logger = new Logger('git');
@@ -31,6 +32,30 @@ export class Git {
     this._logger.info(`\tis ignored: ${ignored}`);
 
     return ignored;
+  }
+
+  public getChangedFiles(targetBranch: string, workspaceFolder: Uri): Uri[] {
+    this._logger.info(`getting files changed compared to branch: ${targetBranch}`);
+    
+    try {
+      const result = this.executeGit({ 
+        args: ['diff', '--name-only', targetBranch], 
+        cwd: workspaceFolder.fsPath,
+      });
+      
+      const changedFiles = result
+        .trim()
+        .split('\n')
+        .filter(file => file.length > 0)
+        .map(file => Uri.file(path.join(workspaceFolder.fsPath, file)));
+      
+      this._logger.info(`found ${changedFiles.length} changed files:\n${changedFiles.map(f => f.fsPath).join('\n')}`);
+      return changedFiles;
+    }
+    catch (error) {
+      this._logger.error(`Failed to get changed files: ${error}`);
+      throw new Error(`Failed to get changed files from branch comparison: ${error}`);
+    }
   }
 
   private executeGit(options: { cwd: string, args: string[] }): string {

--- a/src/ext/utilities/git.ts
+++ b/src/ext/utilities/git.ts
@@ -1,7 +1,7 @@
 import { extensions, Uri } from 'vscode';
 import { Logger } from './logger';
 import { execFileSync } from 'child_process';
-import * as path from 'path';
+import { join } from 'path';
 
 export class Git {
   private _logger = new Logger('git');
@@ -47,7 +47,7 @@ export class Git {
         .trim()
         .split('\n')
         .filter(file => file.length > 0)
-        .map(file => Uri.file(path.join(workspaceFolder.fsPath, file)));
+        .map(file => Uri.file(join(workspaceFolder.fsPath, file)));
 
       this._logger.info(`found ${changedFiles.length} changed files:\n${changedFiles.map(f => f.fsPath).join('\n')}`);
       return changedFiles;

--- a/src/ext/utilities/git.ts
+++ b/src/ext/utilities/git.ts
@@ -36,19 +36,19 @@ export class Git {
 
   public getChangedFiles(targetBranch: string, workspaceFolder: Uri): Uri[] {
     this._logger.info(`getting files changed compared to branch: ${targetBranch}`);
-    
+
     try {
-      const result = this.executeGit({ 
-        args: ['diff', '--name-only', targetBranch], 
+      const result = this.executeGit({
+        args: ['diff', '--name-only', targetBranch],
         cwd: workspaceFolder.fsPath,
       });
-      
+
       const changedFiles = result
         .trim()
         .split('\n')
         .filter(file => file.length > 0)
         .map(file => Uri.file(path.join(workspaceFolder.fsPath, file)));
-      
+
       this._logger.info(`found ${changedFiles.length} changed files:\n${changedFiles.map(f => f.fsPath).join('\n')}`);
       return changedFiles;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { formatFiles } from './ext/commands/format-files';
 import { validateInWorkspace } from './ext/commands/validate-in-workspace';
 import { Config } from './ext/utilities/config';
 import { FileQueryApi } from './ext/queries/file-query-api';
+import { Git } from './ext/utilities/git';
 
 const logger = new Logger('ext');
 
@@ -24,6 +25,10 @@ export function activate(context: ExtensionContext): void {
     context,
     Constants.formatFilesFromGlob,
     fromGlob);
+  registerCommand(
+    context,
+    Constants.formatFilesFromBranch,
+    fromBranch);
 
   logger.info('activated');
 }
@@ -67,6 +72,32 @@ async function fromGlob(): Promise<void> {
     const useDefaultExcludes = await prompts.useDefaultExcludes();
     const files = await FileQueryApi.getWorkspaceFilesWithGlob(workspaceFolder, { glob, useDefaultExcludes });
     await prompts.confirmStart(`Format Files: Start formatting ${files.length} workspace files using glob '${glob}'?`);
+    await formatFiles(files);
+
+    logger.info(`Format Files completed`);
+  }
+  catch (error) {
+    logger.error(error);
+  }
+}
+
+async function fromBranch(): Promise<void> {
+  try {
+    Config.load();
+    openOutputChannel();
+    logger.info(`Starting Format Files - By Branch Changes`);
+    validateInWorkspace();
+    const workspaceFolder = await prompts.selectWorkspaceFolder();
+    const targetBranch = await prompts.requestBranch();
+    const git = new Git();
+    const files = git.getChangedFiles(targetBranch, workspaceFolder.uri);
+    
+    if (files.length === 0) {
+      await prompts.confirmStart(`No files changed compared to '${targetBranch}'. Nothing to format.`);
+      return;
+    }
+    
+    await prompts.confirmStart(`Format Files: Start formatting ${files.length} files changed since '${targetBranch}'?`);
     await formatFiles(files);
 
     logger.info(`Format Files completed`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,12 +91,12 @@ async function fromBranch(): Promise<void> {
     const targetBranch = await prompts.requestBranch();
     const git = new Git();
     const files = git.getChangedFiles(targetBranch, workspaceFolder.uri);
-    
+
     if (files.length === 0) {
       await prompts.confirmStart(`No files changed compared to '${targetBranch}'. Nothing to format.`);
       return;
     }
-    
+
     await prompts.confirmStart(`Format Files: Start formatting ${files.length} files changed since '${targetBranch}'?`);
     await formatFiles(files);
 


### PR DESCRIPTION
Adds a new command to format only files that have changed compared to a target branch.

**Use case:** 
Format just the files you've modified in your feature branch before committing.

**What it does:**
- Prompts for target branch name (e.g., `main`, `master`) 
- Remembers your last used branch for convenience
- Uses `git diff --name-only` to find changed files
- Skips git-ignored files automatically
- Formats only the files that differ from the target branch

**New command:** "Start Format Files: Changed in Branch"